### PR TITLE
Add routing with hash router

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 node_modules
-public
+public/dist
 
 .vscode

--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -1,7 +1,26 @@
 import React from 'react';
+import {
+  HashRouter as Router,
+  Routes,
+  Route,
+} from 'react-router-dom';
+
+import Home from './Home/index';
+import Products from './Products/index';
+import Profile from './Profile/index';
+import Lifestyle from './Lifestyle/index';
+import NotFound from './NotFound/index';
 
 const App = () => (
-  <h1>Hello, world!</h1>
+  <Router>
+    <Routes>
+      <Route exact path="/" element={<Home />} />
+      <Route path="products" element={<Products />} />
+      <Route path="profile" element={<Profile />} />
+      <Route path="lifestyle" element={<Lifestyle />} />
+      <Route path="*" element={<NotFound />} />
+    </Routes>
+  </Router>
 );
 
 export default App;

--- a/client/components/Home/index.jsx
+++ b/client/components/Home/index.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const Home = () => (
+  <h2>Home</h2>
+);
+
+export default Home;

--- a/client/components/Lifestyle/index.jsx
+++ b/client/components/Lifestyle/index.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const Lifestyle = () => (
+  <h2>Lifestyle</h2>
+);
+
+export default Lifestyle;

--- a/client/components/NotFound/index.jsx
+++ b/client/components/NotFound/index.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const NotFound = () => (
+  <h2>Page not found</h2>
+);
+
+export default NotFound;

--- a/client/components/Products/index.jsx
+++ b/client/components/Products/index.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const Products = () => (
+  <h2>Products</h2>
+);
+
+export default Products;

--- a/client/components/Profile/index.jsx
+++ b/client/components/Profile/index.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const Profile = () => (
+  <h2>Profile</h2>
+);
+
+export default Profile;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1246,7 +1246,6 @@
       "version": "7.16.3",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.3.tgz",
       "integrity": "sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==",
-      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -3300,6 +3299,14 @@
       "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
       "dev": true
     },
+    "history": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.1.0.tgz",
+      "integrity": "sha512-zPuQgPacm2vH2xdORvGGz1wQMuHSIB56yNAy5FnLuwOwgSYyPKptJtcMm6Ev+hRGeS+GzhbmRacHzvlESbFwDg==",
+      "requires": {
+        "@babel/runtime": "^7.7.6"
+      }
+    },
     "http-cache-semantics": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
@@ -4404,6 +4411,23 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
     },
+    "react-router": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.0.2.tgz",
+      "integrity": "sha512-8/Wm3Ed8t7TuedXjAvV39+c8j0vwrI5qVsYqjFr5WkJjsJpEvNSoLRUbtqSEYzqaTUj1IV+sbPJxvO+accvU0Q==",
+      "requires": {
+        "history": "^5.1.0"
+      }
+    },
+    "react-router-dom": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.0.2.tgz",
+      "integrity": "sha512-cOpJ4B6raFutr0EG8O/M2fEoyQmwvZWomf1c6W2YXBZuFBx8oTk/zqjXghwScyhfrtnt0lANXV2182NQblRxFA==",
+      "requires": {
+        "history": "^5.1.0",
+        "react-router": "6.0.2"
+      }
+    },
     "readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -4440,8 +4464,7 @@
     "regenerator-runtime": {
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
-      "dev": true
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
     },
     "regenerator-transform": {
       "version": "0.14.5",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "dotenv": "^10.0.0",
     "express": "^4.17.1",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react-dom": "^17.0.2",
+    "react-router-dom": "^6.0.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.16.0",

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Best Eats</title>
+  </head>
+  <body>
+    <div id="root"></div>
+	  <script src="dist/main.js"></script>
+  </body>
+</html>

--- a/server/index.js
+++ b/server/index.js
@@ -1,4 +1,3 @@
 const app = require('./app');
 
 app.listen(3000, () => console.log('now listening on port 3000'));
-


### PR DESCRIPTION
I added a router in our app with `HashRouter`. The router supports 4 routes currently and an extra route handling any unmatched routes. Since this we are utilizing hash router, routes will be prefixed with a `#`.

The following routes have been updated:

- Home - `http://localhost:3000/#/`
- Products - `http://localhost:3000/#/products`
- Profile - `http://localhost:3000/#/profile`
- Lifestyle - `http://localhost:3000/#/lifestyle`
- Error - unhandled routes

These can be changed in the future depending on feedback on our proposal & how we decide to structure the app.